### PR TITLE
Fix negative height calculation bug & expose texture settings for better clarity

### DIFF
--- a/Assets/SimpleUnity3DWebView/Scripts/WebViewManager.cs
+++ b/Assets/SimpleUnity3DWebView/Scripts/WebViewManager.cs
@@ -16,6 +16,12 @@ namespace WebView
         [SerializeField] private string defaultUrl = "https://www.google.com/";
         [SerializeField] private Vector2 normalizedTouchSlop = Vector2.one * 0.05f;
 
+        [Header("Texture Properties")]
+        [SerializeField] private bool defaultMipChain = true;
+        [SerializeField] private FilterMode defaultFilterMode = FilterMode.Trilinear;
+        [Range(0, 16)]
+        [SerializeField] private int defaultAnisoLebel = 8;
+
         [Header("Events")]
         [SerializeField] private UnityEvent<string> urlChanged = default!;
         [SerializeField] private UnityEvent<ReceivedData> dataReceived = default!;
@@ -23,6 +29,8 @@ namespace WebView
         private WebViewJavaBridge? bridge;
         private WebViewDataReceiver? receiver;
         private WebViewTextureUpdater? textureUpdater;
+
+        public Texture Texture => webViewImage.texture;
 
         public void LoadUrl(string url) => bridge?.LoadUrl(url);
         public void Reload() => bridge?.Reload();
@@ -56,7 +64,9 @@ namespace WebView
                 WebViewDataReceiver.JsonMessageMethodName
             );
 
-            var texture = new Texture2D(textureWidth, textureHeight);
+            var texture = new Texture2D(textureWidth, textureHeight, TextureFormat.RGBA32, defaultMipChain);
+            texture.filterMode = defaultFilterMode;
+            texture.anisoLevel = defaultAnisoLebel;
             webViewImage.texture = texture;
 
             textureUpdater = new WebViewTextureUpdater(bridge, texture);

--- a/Assets/SimpleUnity3DWebView/Scripts/WebViewManager.cs
+++ b/Assets/SimpleUnity3DWebView/Scripts/WebViewManager.cs
@@ -37,7 +37,7 @@ namespace WebView
 
             var imageRectSize = webViewImage.rectTransform.sizeDelta;
             var aspect = imageRectSize.y / imageRectSize.x;
-            var textureHeight = (int)(textureWidth * aspect);
+            var textureHeight = (int) Mathf.Abs(textureWidth * aspect);
 
             var receiverObject = new GameObject(id);
             receiverObject.transform.parent = transform;

--- a/ProjectSettings/QualitySettings.asset
+++ b/ProjectSettings/QualitySettings.asset
@@ -308,6 +308,7 @@ QualitySettings:
     Nintendo Switch: 5
     PS4: 5
     PSP2: 2
+    Server: 0
     Stadia: 5
     Standalone: 5
     WebGL: 3


### PR DESCRIPTION
- Fixed a bug where texture height could become negative during calculation.
- Exposed texture settings as public fields to allow configuration via the Inspector, improving code clarity and flexibility.